### PR TITLE
Redirect when GETing /order/confirm instead of 404

### DIFF
--- a/app/controllers/boutique/orders_controller.rb
+++ b/app/controllers/boutique/orders_controller.rb
@@ -95,6 +95,10 @@ class Boutique::OrdersController < Boutique::ApplicationController
     end
   end
 
+  def get_confirm
+    redirect_to action: :edit
+  end
+
   def show
     @use_boutique_adaptive_css = :no_background
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Boutique::Engine.routes.draw do
     get :crossdomain_add, path: "crossdomain_add/:product_variant_slug"
     post :add
     post :confirm
+    get :get_confirm, to: :get_confirm, path: "/confirm"
     post :apply_voucher
     post :payment, path: "/:id/payment"
   end

--- a/test/controllers/boutique/orders_controller_test.rb
+++ b/test/controllers/boutique/orders_controller_test.rb
@@ -78,6 +78,15 @@ class Boutique::OrdersControllerTest < Boutique::ControllerTest
     assert @order.primary_address.present?
   end
 
+  test "get_confirm" do
+    get confirm_order_url
+    assert_redirected_to main_app.root_url
+
+    create_order_with_current_session_id
+    get confirm_order_url
+    assert_redirected_to edit_order_url
+  end
+
   test "show" do
     order = create(:boutique_order, :ready_to_be_confirmed)
     assert_raises(ActiveRecord::RecordNotFound) { get order_url(order.secret_hash) }


### PR DESCRIPTION
When confirming an invalid order, the user stays on `/order/confirm`.

Refreshing causes 404 as `orders#show` catches the path. This catches the `confirm` "id" and redirects to `orders#edit`