### PR TITLE
feat(checkout): restore multi-month subscription options

### DIFF
--- a/app/cells/boutique/orders/cart/recurrency_fields/show.slim
+++ b/app/cells/boutique/orders/cart/recurrency_fields/show.slim
@@ -15,14 +15,25 @@ div class=class_name
               .b-orders-cart-recurrency-fields__option-text
                 = text_true
 
-        label.b-orders-cart-recurrency-fields__option
-            = g.radio_button :subscription_recurring,
-                             false,
-                             class: "b-orders-cart-recurrency-fields__option-input"
+        label.b-orders-cart-recurrency-fields__show-nonrecurring-button
+          = t('.nonrecurring_payment.link')
 
-            .b-orders-cart-recurrency-fields__option-content
-            .b-orders-cart-recurrency-fields__option-title
-                = "Nechci opakovanou platbu, zaplatím jednorázově."
+          input.b-orders-cart-recurrency-fields__show-nonrecurring-button-input[
+            type="checkbox"
+            name="nonrecurring_payment_visible"
+          ]
+
+        .b-orders-cart-recurrency-fields__nonrecurring-payment
+          .b-orders-cart-recurrency-fields__nonrecurring-payment-title
+            = t('.nonrecurring_payment.title')
+
+          - g.object.subscription_period_options_for_select.each do |label, n|
+            label.b-orders-cart-recurrency-fields__nonrecurring-payment-option
+              = g.radio_button :subscription_period,
+                               n,
+                               class: nonrecurring_payment_option_input_class_name
+
+              span = label
 
         - if show_error_message?
           .b-orders-cart-recurrency-fields__error.text-danger

--- a/app/cells/boutique/orders/cart/voucher_fields/show.slim
+++ b/app/cells/boutique/orders/cart/voucher_fields/show.slim
@@ -6,11 +6,11 @@ div class=class_name
       = input
 
       .b-orders-cart-voucher-fields__right
-      span.b-orders-cart-voucher-fields__apply.small[
-          data-url=controller.boutique.apply_voucher_checkout_path(format: :json)
-          data-error=t('.generic_error')
-      ]
-          = t(".apply")
+        span.b-orders-cart-voucher-fields__apply.small[
+            data-url=controller.boutique.apply_voucher_checkout_path(format: :json)
+            data-error=t('.generic_error')
+        ]
+            = t(".apply")
 
       img.b-orders-cart-voucher-fields__applied[
           src=image_path('boutique/coupon-applied.svg')

--- a/app/cells/boutique/orders/cart/voucher_fields/show.slim
+++ b/app/cells/boutique/orders/cart/voucher_fields/show.slim
@@ -6,11 +6,11 @@ div class=class_name
       = input
 
       .b-orders-cart-voucher-fields__right
-        span.b-orders-cart-voucher-fields__apply.small[
-            data-url=controller.boutique.apply_voucher_checkout_path(format: :json)
-            data-error=t('.generic_error')
-        ]
-            = t(".apply")
+      span.b-orders-cart-voucher-fields__apply.small[
+          data-url=controller.boutique.apply_voucher_checkout_path(format: :json)
+          data-error=t('.generic_error')
+      ]
+          = t(".apply")
 
       img.b-orders-cart-voucher-fields__applied[
           src=image_path('boutique/coupon-applied.svg')

--- a/app/cells/boutique/orders/cart/voucher_fields/show.slim
+++ b/app/cells/boutique/orders/cart/voucher_fields/show.slim
@@ -7,16 +7,16 @@ div class=class_name
 
       .b-orders-cart-voucher-fields__right
         span.b-orders-cart-voucher-fields__apply.small[
-            data-url=controller.boutique.apply_voucher_checkout_path(format: :json)
-            data-error=t('.generic_error')
+          data-url=controller.boutique.apply_voucher_checkout_path(format: :json)
+          data-error=t('.generic_error')
         ]
-            = t(".apply")
+          = t(".apply")
 
-      img.b-orders-cart-voucher-fields__applied[
+        img.b-orders-cart-voucher-fields__applied[
           src=image_path('boutique/coupon-applied.svg')
           width=20
           height=20
-      ]
+        ]
 
       span.folio-loader.folio-loader--small.b-orders-cart-voucher-fields__loader
 

--- a/app/cells/boutique/orders/summary_cell.rb
+++ b/app/cells/boutique/orders/summary_cell.rb
@@ -28,19 +28,19 @@ class Boutique::Orders::SummaryCell < Boutique::ApplicationCell
   end
 
   def line_item_tag_additional_class(line_item)
-    if line_item.subscription_recurring? || line_item.subscription_recurring.nil?
+    if line_item.subscription_recurring? || line_item.subscription_period.nil?
       "b-orders-summary__tag--recurring"
     end
   end
 
   def line_item_tag_label(line_item)
-    if line_item.subscription_recurring? || line_item.subscription_recurring.nil?
+    if line_item.subscription_recurring? || line_item.subscription_period.nil?
       [
         image_tag("boutique/refresh.svg", class: "b-orders-summary__tag-img"),
         t(".recurring_payment")
       ].join
     else
-      t(".single_payment", months: duration_to_human(1))
+      t(".single_payment", months: duration_to_human(line_item.subscription_period))
     end
   end
 

--- a/app/models/boutique/line_item.rb
+++ b/app/models/boutique/line_item.rb
@@ -20,6 +20,7 @@ class Boutique::LineItem < Boutique::ApplicationRecord
            :subscription?,
            to: :product
 
+  after_initialize :set_default_subscription_recurring
   before_validation :unset_unwanted_subscription_starts_at
 
   def title
@@ -100,7 +101,7 @@ class Boutique::LineItem < Boutique::ApplicationRecord
 
     if subscription?
       self.subscription_starts_at = subscription_starts_at
-      self.subscription_period = product_variant.subscription_period
+      self.subscription_period = product_variant.subscription_period if subscription_recurring?
     end
 
     self
@@ -126,7 +127,7 @@ class Boutique::LineItem < Boutique::ApplicationRecord
   end
 
   def self.subscription_period_options
-    [1]
+    [1, 3, 6, 12]
   end
 
   def self.subscription_period_options_for_select
@@ -147,6 +148,10 @@ class Boutique::LineItem < Boutique::ApplicationRecord
   private
     def subscription_starts_at_label(date, number)
       "#{I18n.t('boutique.issue').capitalize} #{number} / #{date.year}"
+    end
+
+    def set_default_subscription_recurring
+      self.subscription_recurring ||= false
     end
 
     def unset_unwanted_subscription_starts_at

--- a/app/models/boutique/order.rb
+++ b/app/models/boutique/order.rb
@@ -1010,7 +1010,7 @@ class Boutique::Order < Boutique::ApplicationRecord
       return unless recurrent_payment_available?
 
       li = subscription_line_item
-      if li && !li.marked_for_destruction? && li.requires_subscription_recurring? && li.subscription_recurring.nil?
+      if li && !li.marked_for_destruction? && li.requires_subscription_recurring? && !li.subscription_recurring? && li.subscription_period.nil?
         errors.add(:line_items, :missing_subscription_recurrence)
       end
     end


### PR DESCRIPTION
## Summary
- Restore 3, 6, and 12 month subscription period options in checkout flow
- Revert commit b911de67 that disabled multi-month subscriptions
- Fix voucher_fields template structure issues

## Changes
- `recurrency_fields/show.slim` - restored period selection UI
- `voucher_fields/show.slim` - fixed indentation and structure
- `line_item.rb` - restored subscription_period_options to [1, 3, 6, 12]
- `summary_cell.rb` - display actual selected period
- `order.rb` - restored validation for subscription_period

Related: GAZ-146