### PR TITLE
feat(subscription): yearly subscription support

### DIFF
--- a/app/lib/boutique/mailer_bot.rb
+++ b/app/lib/boutique/mailer_bot.rb
@@ -14,7 +14,7 @@ class Boutique::MailerBot
     subscriptions_failed_payment
     subscriptions_unpaid
     subscriptions_expiring_soon
-    # subscriptions_will_end_in_a_week
+    subscriptions_will_end_in_a_week
   end
 
   def orders_unpaid_reminder

--- a/app/models/boutique/product/subscription.rb
+++ b/app/models/boutique/product/subscription.rb
@@ -6,6 +6,7 @@ class Boutique::Product::Subscription < Boutique::Product
     monthly: 1,
     bimonthly: 2,
     quarterly: 3,
+    yearly: 12,
   }
 
   validates :subscription_frequency, inclusion: { in: SUBSCRIPTION_FREQUENCIES.keys.map(&:to_s) }

--- a/config/locales/activerecord.cs.yml
+++ b/config/locales/activerecord.cs.yml
@@ -95,6 +95,7 @@ cs:
         subscription_frequency/bimonthly: dvouměsíční
         subscription_frequency/monthly: měsíční
         subscription_frequency/quarterly: čtvrtletní
+        subscription_frequency/yearly: roční
         subscription_frequency: Periodicita
         subscription_recurrent_payment_disabled: Zakázat možnost opakované platby
         type: Typ produktu

--- a/test/lib/boutique/mailer_bot_test.rb
+++ b/test/lib/boutique/mailer_bot_test.rb
@@ -107,6 +107,18 @@ class Boutique::MailerBotTest < ActiveSupport::TestCase
     assert_equal [target.id], @bot.send(:subscriptions_for_will_end_in_a_week).map(&:id)
   end
 
+  test "all dispatches will_end_in_a_week mailer for non-recurring subs ending in one week" do
+    target = create(:boutique_subscription, active_until: now + 1.week, recurrent: false)
+    create(:boutique_subscription, active_until: now + 1.week, recurrent: true)
+    create(:boutique_subscription, active_until: now + 1.week + 1.day, recurrent: false)
+
+    Boutique::SubscriptionMailer.expects(:will_end_in_a_week)
+                                .with { |sub| sub.id == target.id }
+                                .returns(stub(deliver_later: true))
+
+    @bot.all
+  end
+
   test "subscriptions_expiring_soon" do
     travel_to Time.current.change(hour: 7)
 

--- a/test/models/boutique/product/subscription_test.rb
+++ b/test/models/boutique/product/subscription_test.rb
@@ -27,6 +27,12 @@ class Boutique::Product::SubscriptionTest < ActiveSupport::TestCase
     assert_equal 3, issue[:number]
     assert_equal 7, issue[:month]
     assert_equal 2022, issue[:year]
+
+    @subscription.subscription_frequency = "yearly"
+    issue = @subscription.issue_at(date)
+    assert_equal 1, issue[:number]
+    assert_equal 1, issue[:month]
+    assert_equal 2022, issue[:year]
   end
 
   test "SUBSCRIPTION_FREQUENCIES includes yearly with 12 months per issue" do

--- a/test/models/boutique/product/subscription_test.rb
+++ b/test/models/boutique/product/subscription_test.rb
@@ -28,4 +28,24 @@ class Boutique::Product::SubscriptionTest < ActiveSupport::TestCase
     assert_equal 7, issue[:month]
     assert_equal 2022, issue[:year]
   end
+
+  test "SUBSCRIPTION_FREQUENCIES includes yearly with 12 months per issue" do
+    assert_equal 12, Boutique::Product::Subscription::SUBSCRIPTION_FREQUENCIES[:yearly]
+  end
+
+  test "subscription_frequency: yearly is a valid value" do
+    @subscription.subscription_frequency = "yearly"
+    @subscription.valid?
+    assert_not_includes @subscription.errors[:subscription_frequency].to_s, "is not included in the list"
+  end
+
+  test "subscription_frequency_in_months_per_issue returns 12 for yearly" do
+    @subscription.subscription_frequency = "yearly"
+    assert_equal 12, @subscription.subscription_frequency_in_months_per_issue
+  end
+
+  test "subscription_frequency_in_issues_per_year returns 1 for yearly" do
+    @subscription.subscription_frequency = "yearly"
+    assert_equal 1, @subscription.subscription_frequency_in_issues_per_year
+  end
 end


### PR DESCRIPTION
Per-gazetisto branch for GAZ-162. Two changes:

1. Add `yearly: 12` to `Boutique::Product::Subscription::SUBSCRIPTION_FREQUENCIES` (+ Czech i18n entry `roční`).
2. Enable `subscriptions_will_end_in_a_week` reminder in `Boutique::MailerBot#all`.

Both changes are gated by gazetistos consumer needs (yearly prepaid product variants with end-of-subscription reminder mail). No other apps point at this branch.

Linked tickets: https://sinfin-digital.atlassian.net/browse/GAZ-162
Gazetisto-side branch: `gaz-162-yearly-subscription` (pinned in Gemfile).