### PR TITLE
feat(console): add refunds column to orders catalogue

### DIFF
--- a/app/cells/folio/console/boutique/orders/catalogue/show.slim
+++ b/app/cells/folio/console/boutique/orders/catalogue/show.slim
@@ -56,4 +56,14 @@
         end
       end
 
+      attribute(:refunds, compact: true) do
+        record.refunds.sort_by(&:created_at).map do |refund|
+          label = refund.document_number.presence || "##{refund.id}"
+          link = link_to(label,
+                         controller.folio.url_for([:console, refund]),
+                         target: "_blank")
+          refund.aasm_state == "cancelled" ? content_tag(:s, link) : link
+        end.join(" ").html_safe
+      end
+
       actions :show, :edit

--- a/config/locales/activerecord.cs.yml
+++ b/config/locales/activerecord.cs.yml
@@ -42,6 +42,7 @@ cs:
         primary_address_country_code: Země odběru
         product: Produkt
         product_type_keyword: Druh produktu
+        refunds: Vratky
         shipping_price: Cena dopravy
         subscription_state/active: Aktivní předplatné
         subscription_state/inactive: Neaktivní předplatné

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -21,6 +21,7 @@ en:
         primary_address_country_code/SK: Slovakia
         primary_address_country_code: Country
         product_type_keyword: Product type
+        refunds: Refunds
         subscription_state/active: Active
         subscription_state/inactive: Inactive
         subscription_state/none: None

--- a/test/cells/folio/console/boutique/orders/catalogue_cell_test.rb
+++ b/test/cells/folio/console/boutique/orders/catalogue_cell_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Folio::Console::Boutique::Orders::CatalogueCellTest < Folio::Console::CellTest
+  # Cell rendering goes through Folio::Console::BaseController#current_ability
+  # → Devise's current_account → Warden, which is not available in cell tests.
+  # Patch the permission check directly so rows render via show_link.
+  # Done via Module#prepend (survives across tests) rather than Mocha any_instance
+  # stubs which would only apply per-test.
+  module StubPermissions
+    def can?(*); true; end
+  end
+  Folio::Console::BaseController.prepend(StubPermissions) unless Folio::Console::BaseController < StubPermissions
+
+  test "renders catalogue wrapper for empty collection" do
+    html = cell("folio/console/boutique/orders/catalogue", Boutique::Order.none).(:show)
+    assert html.has_css?(".f-c-b-orders-catalogue")
+  end
+
+  test "renders catalogue for order without refunds" do
+    order = create(:boutique_order, :paid)
+    html = cell("folio/console/boutique/orders/catalogue", Boutique::Order.where(id: order.id)).(:show)
+    assert html.has_css?(".f-c-b-orders-catalogue")
+    refute html.has_css?("s"), "Empty refunds column should not render a <s> element"
+  end
+
+  test "renders link with document_number for paid refund" do
+    refund = create(:boutique_order_refund, :paid)
+    html = cell("folio/console/boutique/orders/catalogue", Boutique::Order.where(id: refund.order.id)).(:show)
+    assert html.has_link?(refund.document_number),
+           "Expected catalogue to contain a link with text #{refund.document_number.inspect}"
+  end
+
+  test "renders links for multiple refunds on a single order" do
+    # OrderRefund validates that sum of refunds doesnt exceed order total.
+    # Default factory creates refund with total_price = order.total_price,
+    # so we need partial refunds for both to fit.
+    order = create(:boutique_order, :paid, total_price: 200)
+    refund1 = create(:boutique_order_refund, :paid, order: order, total_price_in_cents: 8000)
+    refund2 = create(:boutique_order_refund, :paid, order: order, total_price_in_cents: 8000)
+
+    html = cell("folio/console/boutique/orders/catalogue", Boutique::Order.where(id: order.id)).(:show)
+
+    assert html.has_link?(refund1.document_number)
+    assert html.has_link?(refund2.document_number)
+  end
+
+  test "renders cancelled refund with strikethrough and no document_number fallback to id" do
+    refund = create(:boutique_order_refund, :cancelled)
+    html = cell("folio/console/boutique/orders/catalogue", Boutique::Order.where(id: refund.order.id)).(:show)
+
+    # cancelled refunds have no document_number; render fallback "#<id>"
+    fallback_label = "##{refund.id}"
+    assert html.has_link?(fallback_label),
+           "Expected fallback label #{fallback_label.inspect} for cancelled refund"
+    assert html.has_css?("s a", text: fallback_label),
+           "Expected cancelled refund link to be wrapped in <s> (strikethrough)"
+  end
+
+  test "renders paid refund without strikethrough" do
+    refund = create(:boutique_order_refund, :paid)
+    html = cell("folio/console/boutique/orders/catalogue", Boutique::Order.where(id: refund.order.id)).(:show)
+
+    refute html.has_css?("s a", text: refund.document_number),
+           "Paid refund should NOT be wrapped in <s>"
+  end
+end


### PR DESCRIPTION
## Summary

Adds a refunds column to the `Folio::Console::Boutique::Orders::CatalogueCell` (orders list in admin), placed right before the action buttons. Each refund linked to an order renders as a compact link to its console detail with its `document_number` (or `#<id>` fallback for refunds that never got approved). Cancelled refunds are wrapped in `<s>` for visual distinction without using a color badge.

## Motivation

When an order has a refund, the order itself stays in its original state (e.g. `dispatched`), so the orders list does not signal that a refund exists. Admins had to open each order detail to find linked refunds. This is especially painful after a batch refund event — e.g. after the GAZ-169 outage on 2026-05-21 we ended up with 124 orders that needed refunds, and identifying them in the list was impossible without clicking into each one.

## Behaviour

- Empty refunds → empty column (no rendering)
- Paid / approved_to_pay refund → plain link with `document_number`
- Created (draft) refund without `document_number` → link with `#<id>` fallback
- Cancelled refund → link wrapped in `<s>` (strikethrough)
- Multiple refunds on the same order → all rendered, sorted by `created_at`

## Tests

Added `test/cells/folio/console/boutique/orders/catalogue_cell_test.rb` with 6 cases covering all the above. Done TDD-style; full boutique cell suite still passes (56 runs, 0 failures).

## App-integrator note

To avoid N+1 queries, apps should add `:refunds` to `Boutique.config.folio_console_collection_includes_for_orders`. Gazetisto config already updated in [sinfin/gazetisto commit e3665b3].

## Test infrastructure note

The new cell test required permission stubbing (via `Module#prepend`) because `Folio::Console::BaseController#current_ability` calls Devise which is not available in cell tests. This pattern can be reused for future cell tests in boutique.